### PR TITLE
Fix #66021 (Blank line inside empty array/object)

### DIFF
--- a/json.c
+++ b/json.c
@@ -355,7 +355,7 @@ static inline void json_pretty_print_indent(smart_str *buf, int options TSRMLS_D
 
 static void json_encode_array(smart_str *buf, zval **val, int options TSRMLS_DC) /* {{{ */
 {
-	int i, r;
+	int i, r, need_comma = 0;
 	HashTable *myht;
 
 	if (Z_TYPE_PP(val) == IS_ARRAY) {
@@ -378,7 +378,6 @@ static void json_encode_array(smart_str *buf, zval **val, int options TSRMLS_DC)
 		smart_str_appendc(buf, '{');
 	}
 
-	json_pretty_print_char(buf, options, '\n' TSRMLS_CC);
 	++JSON_G(encoder_depth);
 
 	i = myht ? zend_hash_num_elements(myht) : 0;
@@ -391,7 +390,6 @@ static void json_encode_array(smart_str *buf, zval **val, int options TSRMLS_DC)
 		uint key_len;
 		HashPosition pos;
 		HashTable *tmp_ht;
-		int need_comma = 0;
 
 		zend_hash_internal_pointer_reset_ex(myht, &pos);
 		for (;; zend_hash_move_forward_ex(myht, &pos)) {
@@ -408,11 +406,11 @@ static void json_encode_array(smart_str *buf, zval **val, int options TSRMLS_DC)
 				if (r == PHP_JSON_OUTPUT_ARRAY) {
 					if (need_comma) {
 						smart_str_appendc(buf, ',');
-						json_pretty_print_char(buf, options, '\n' TSRMLS_CC);
 					} else {
 						need_comma = 1;
 					}
 
+					json_pretty_print_char(buf, options, '\n' TSRMLS_CC);
 					json_pretty_print_indent(buf, options TSRMLS_CC);
 					php_json_encode(buf, *data, options TSRMLS_CC);
 				} else if (r == PHP_JSON_OUTPUT_OBJECT) {
@@ -427,11 +425,11 @@ static void json_encode_array(smart_str *buf, zval **val, int options TSRMLS_DC)
 
 						if (need_comma) {
 							smart_str_appendc(buf, ',');
-							json_pretty_print_char(buf, options, '\n' TSRMLS_CC);
 						} else {
 							need_comma = 1;
 						}
 
+						json_pretty_print_char(buf, options, '\n' TSRMLS_CC);
 						json_pretty_print_indent(buf, options TSRMLS_CC);
 
 						json_escape_string(buf, key, key_len - 1, options & ~PHP_JSON_NUMERIC_CHECK TSRMLS_CC);
@@ -443,11 +441,11 @@ static void json_encode_array(smart_str *buf, zval **val, int options TSRMLS_DC)
 					} else {
 						if (need_comma) {
 							smart_str_appendc(buf, ',');
-							json_pretty_print_char(buf, options, '\n' TSRMLS_CC);
 						} else {
 							need_comma = 1;
 						}
 
+						json_pretty_print_char(buf, options, '\n' TSRMLS_CC);
 						json_pretty_print_indent(buf, options TSRMLS_CC);
 
 						smart_str_appendc(buf, '"');
@@ -472,8 +470,12 @@ static void json_encode_array(smart_str *buf, zval **val, int options TSRMLS_DC)
 		JSON_G(error_code) = PHP_JSON_ERROR_DEPTH;
 	}
 	--JSON_G(encoder_depth);
-	json_pretty_print_char(buf, options, '\n' TSRMLS_CC);
-	json_pretty_print_indent(buf, options TSRMLS_CC);
+
+	/* Only keep closing bracket on same line for empty arrays/objects */
+	if (need_comma) {
+		json_pretty_print_char(buf, options, '\n' TSRMLS_CC);
+		json_pretty_print_indent(buf, options TSRMLS_CC);
+	}
 
 	if (r == PHP_JSON_OUTPUT_ARRAY) {
 		smart_str_appendc(buf, ']');

--- a/tests/bug66021.phpt
+++ b/tests/bug66021.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Bug #66021 (Blank line inside empty array/object when JSON_PRETTY_PRINT is set)
+--SKIPIF--
+<?php if (!extension_loaded("json")) print "skip"; ?>
+--FILE--
+<?php
+
+class Foo {
+	private $bar = 'baz';
+}
+
+echo json_encode([[], (object)[], new Foo], JSON_PRETTY_PRINT), "\n";
+
+?>
+--EXPECT--
+[
+    [],
+    {},
+    {}
+]


### PR DESCRIPTION
Changed json_encode() so that when the JSON_PRETTY_PRINT option is specified,
the pair of linefeeds immediately after an opening bracket and before the
corresponding closing bracket is omitted when the array or object contains no
elements or accessible properties (and hence would have a blank line between
the brackets).

(from php/php-src@82a4f1a1a287d9dbf01156bc14ceb13ccbf16d7a)
