### PR TITLE
Invalid string to float convertion

### DIFF
--- a/tests/issue27.phpt
+++ b/tests/issue27.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Issue #27 json_decode: invalid string to float conversion
+--SKIPIF--
+<?php if (!extension_loaded('json')) print 'skip'; ?>
+--FILE--
+<?php
+// String
+$json = "3.333.3.";
+var_dump(json_decode($json));
+var_dump(json_last_error());
+var_dump(json_last_error_msg());
+?>
+Done
+--EXPECT--
+NULL
+int(4)
+string(12) "Syntax error"
+Done


### PR DESCRIPTION
json-c decodes "3.333.3." to double(3.333) this is different from the default php json_decode
